### PR TITLE
updating import links for shim and peer package

### DIFF
--- a/chaincode/main.go
+++ b/chaincode/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/hyperledger/fabric/core/chaincode/shim"
-	pb "github.com/hyperledger/fabric/protos/peer"
+	"github.com/hyperledger/fabric-chaincode-go/shim"
+	sc "github.com/hyperledger/fabric-protos-go/peer"
 )
 
 // HeroesServiceChaincode implementation of Chaincode


### PR DESCRIPTION
The shim and peer protobuf modules are no longer vendored automatically by Fabric, so they are needed to vendor individually otherwise they lead to the issue as depicted in the attached screenshot.

![chaincode_go_import-error](https://user-images.githubusercontent.com/48702793/131338859-2e473bfb-c575-4c44-921a-a3b364a9106f.png)
